### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/birisdenisalarisa/30b0e83e-9d91-4c32-8faf-8ff221ed42e0/4213e186-db81-46b9-84f6-b1eb7c8492fa/_apis/work/boardbadge/124b4c0b-211f-48a5-99d0-02cf2c9a1413)](https://dev.azure.com/birisdenisalarisa/30b0e83e-9d91-4c32-8faf-8ff221ed42e0/_boards/board/t/4213e186-db81-46b9-84f6-b1eb7c8492fa/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/birisdenisalarisa/30b0e83e-9d91-4c32-8faf-8ff221ed42e0/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.